### PR TITLE
[SSAT] Add ssat to test nnstreamer

### DIFF
--- a/recipes-devtools/ssat/ssat_1.0.0.bb
+++ b/recipes-devtools/ssat/ssat_1.0.0.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Shell Script Automated Tester (unit testing executable files)"
+DESCRIPTION = "Shell Script Automated Tester (unit testing executable files)"
+
+SECTION = "Development"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
+                    file://debian/copyright;md5=9ad9849cc2d52d5b8200d053d510e7d2"
+
+SRC_URI = "git://github.com/nnsuite/SSAT.git;protocol=https"
+
+PV = "1.0.0+git${SRCPV}"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+do_install () {
+     install -d ${D}${bindir}
+     install -p -m 0755 ${S}/ssat.sh ${D}${bindir}/
+     install -p -m 0644 ${S}/ssat-api.sh ${D}${bindir}/
+     cd ${D}${bindir}
+     ln -s ssat.sh ssat
+}
+
+FILES_${PN} += "${bindir}/ssat \
+	    ${bindir}/ssat.sh \
+	    ${bindir}/ssat-api.sh"


### PR DESCRIPTION
# PR Description
Currently NNstreamer uses ssat to run the test cases. It is in the
recipes-devtools dir.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>