### PR TITLE
[Conf/Layer] Increase priority of bb files to 7

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "neuralnetwork"
 
 BBFILE_PATTERN_neuralnetwork = "^${LAYERDIR}/"
-BBFILE_PRIORITY_neuralnetwork = "5"
+BBFILE_PRIORITY_neuralnetwork = "7"
 LAYERVERSION_neuralnetwork = "4"
 LAYERSERIES_COMPAT_neuralnetwork = "thud"


### PR DESCRIPTION
Since meta-neural-network depends on meta-oe, it is required to increase priority of bb files more than 6, which is the priority of bb files in meta-oe.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [*]Skipped
2. Run test: [X]Passed [ ]Failed [* ]Skipped