### PR TITLE
[Support] Add a bitbake recipe for libeigen v.3.3.90

### DIFF
--- a/recipes-support/libeigen/libeigen_3.3.90.bb
+++ b/recipes-support/libeigen/libeigen_3.3.90.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms."
+AUTHOR = "Benoît Jacob, Gaël Guennebaud and others"
+HOMEPAGE = "http://eigen.tuxfamily.org/"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://COPYING.MPL2;md5=815ca599c9df247a0c7f619bab123dad"
+PV = "3.3.90"
+
+SRC_URI = "hg://bitbucket.org/eigen/eigen;protocol=https;module=3.3"
+
+SRCREV = "10938:fd6845384b86"
+S = "${WORKDIR}/3.3"
+DEVEL_PKG_NAME = "${PN}3-dev"
+
+PACKAGES = "${DEVEL_PKG_NAME}"
+PROVIDES += "tflite-1.12-build-dep-${PN}3"
+
+inherit cmake
+FILES_${DEVEL_PKG_NAME} = "${includedir} ${datadir}/eigen3/cmake ${datadir}/pkgconfig"


### PR DESCRIPTION
Although meta-oe already has a bitbake recipe for libeigen v.3.3.7, it is not matched the version needed to build TensorFlow Lite v.1.12. In order to solve this build dependency of TensorFlow Lite v.1.12, this
patch adds a bitbake recipe of a specific revision of libeigen3.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped