### PR TITLE
[Support] Add a bitbake recipe of neon2sse needed by tflite 1.12

### DIFF
--- a/recipes-support/neon2sse/neon2sse_0.0.bb
+++ b/recipes-support/neon2sse/neon2sse_0.0.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "A header file redefining ARM Neon intrinsics in terms of SSE intrinsics \
+    allowing neon code to compile and run on x64/x86 workstantions."
+AUTHOR = "Intel Corporation, Victoria Zhislina"
+HOMEPAGE = "https://github.com/intel/ARM_NEON_2_x86_SSE"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b4fdfcb48f273d192333c498d75fa26f"
+PR = "git2019026.91c5962"
+
+SRC_URI = "git://github.com/intel/ARM_NEON_2_x86_SSE.git"
+SRCREV = "91c5962678271b9c224b5d52a149b19065e65135"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+PROVIDES += "tflite-1.12-build-dep-${PN}"
+


### PR DESCRIPTION
In order to solve the build dependency of TensorFlow Lite v.1.12 on ARM-NEON-2-INTEL-SSE, this patch adds a neon2sse bitbake recipe.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
