### PR TITLE
[DevTools] Add a bitbake recipe for farmhash v.1.1

### DIFF
--- a/recipes-devtools/farmhash/farmhash_1.1.bb
+++ b/recipes-devtools/farmhash/farmhash_1.1.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "FarmHash, a family of hash functions"
+AUTHOR = "Google Inc."
+HOMEPAGE = "https://github.com/google/farmhash"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=7dfaa79e2b070897e495fec386e3acfc"
+PR = "git20170913.816a4ae"
+
+SRC_URI = "git://github.com/google/farmhash.git"
+SRCREV = "816a4ae622e964763ca0862d9dbd19324a1eaf45"
+
+S = "${WORKDIR}/git"
+
+inherit autotools
+
+FILES_${PN} = "${libdir}/*.so.*"
+FILES_${PN}-dev = "${includedir}/*.h \
+    ${libdir}/*.a \
+    ${libdir}/*so"
+FILES_${PN}-doc = "${datadir}/doc/${PN}/*"
+
+PROVIDES += "tflite-1.12-build-dep-farmhash"


### PR DESCRIPTION
This patch adds a bitbake recipe file of farmahsh v.1.1. This recipe uses a specific revision gethered from the download_dependencies.sh script in TensorFlow Lite version 1.12 repository.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [ ]Skipped