### PR TITLE
[DevTools] Add a bitbake recipe for abseil-cpp

### DIFF
--- a/recipes-devtools/abseil-cpp/abseil-cpp_0.0.bb
+++ b/recipes-devtools/abseil-cpp/abseil-cpp_0.0.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "Abseil Common Libraries (C++)"
+AUTHOR = "Google Inc."
+HOMEPAGE = "https://abseil.io"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=df52c6edb7adc22e533b2bacc3bd3915"
+PR = "git20190405.6cc6ac4"
+
+SRC_URI = "git://github.com/abseil/abseil-cpp.git"
+SRCREV = "6cc6ac44e065b9e8975fadfd6ccb99cbcf89aac4"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+PROVIDES += "tflite-1.12-build-dep-absl-cpp"


### PR DESCRIPTION
This patch adds a bitbake recipe for abseil-cpp required to build TensorFlow Lite 1.12. Based on the script, download_dependencies.sh, included in tensorflow/contrib/lite/tools/make, exact matching revision
has been picked for this recipe. 

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped