### PR TITLE
[DevTools] Add a bbappend file of flatbuffers required by tflite v.1.12

### DIFF
--- a/recipes-devtools/flatbuffers/flatbuffers_1.10.0.bbappend
+++ b/recipes-devtools/flatbuffers/flatbuffers_1.10.0.bbappend
@@ -1,0 +1,13 @@
+SRC_URI = "git://github.com/google/flatbuffers.git"
+SRCREV = "1f5eae5d6a135ff6811724f6c57f911d1f46bb15"
+
+PACKAGES_remove = "${PN}-dbg ${PN}-src"
+
+PROVIDES += "tflite-1.12-build-dep-${PN}"
+
+# Override CMAKE options
+EXTRA_OECMAKE = "\
+    -DCMAKE_BUILD_TYPE=Release \
+    -DFLATBUFFERS_BUILD_TESTS=OFF \
+    -DFLATBUFFERS_BUILD_SHAREDLIB=OFF \
+"


### PR DESCRIPTION
In order to provide a build dependency of TensorFlow Lite v.1.12 on flatbuffers, this patch adds a bbappend file for flatbuffers v.1.10. Note that this bbappend file depends on the flatbuffers bitbake recipe
file in meta-oe.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped