### PR TITLE
[Recipe/NNStreamer] Create symlink in ${libdir} to libnnstreamer.so

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
@@ -30,6 +30,11 @@ PACKAGECONFIG[opencv] = "-Denable-opencv-test=true,-Denable-opencv-test=false,op
 PACKAGECONFIG[tensorflow] = "-Denable-tensorflow=true,-Denable-tensorflow=false,tensorflow"
 PACKAGECONFIG[tensorflow-lite] = "-Denable-tensorflow-lite=true,-Denable-tensorflow-lite=false,tensorflow-lite"
 
+do_install_append() {
+    (cd ${D}/${libdir}; ln -s ./gstreamer-1.0/libnnstreamer.so)
+}
+INSANE_SKIP_${PN} += "dev-so"
+
 FILES_${PN} += "${libdir}/*.so \
 	    ${libdir}/gstreamer-1.0/*.so \
 	    ${libdir}/nnstreamer/filters/* \


### PR DESCRIPTION
This patch adds a do_install_append task for creating a symbolic link in ${libdir} to ${libdir}/gstreamer-1.0/libnnstreamer.so.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [  ]Skipped