### PR TITLE
[Recipe/TFLite] Add 'protocol' parameter with 'https' to SRC_URI

### DIFF
--- a/recipes-tensorflow/tensorflow-lite/tensorflow-lite_1.12.bb
+++ b/recipes-tensorflow/tensorflow-lite/tensorflow-lite_1.12.bb
@@ -21,7 +21,7 @@ SHA256SUM_FLATBUFFER = "b2bb0311ca40b12ebe36671bdda350b10c7728caf0cfe2d432ea3b6e
 MD5SUM_FFT = "4255dd8a74949d123216b1ab91520469"
 SHA256SUM_FFT = "52bb637c70b971958ec79c9c8752b1df5ff0218a4db4510e60826e0cb79b5296"
 
-SRC_URI = "git://github.com/tensorflow/tensorflow.git;branch=r1.12 \
+SRC_URI = "git://github.com/tensorflow/tensorflow.git;branch=r1.12;protocol=https \
     https://bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz;md5sum=${MD5SUM_EIGEN};sha256sum=${SHA256SUM_EIGEN} \
     https://mirror.bazel.build/github.com/google/gemmlowp/archive/38ebac7b059e84692f53e5938f97a9943c120d98.zip;md5sum=${MD5SUM_GEMMLOWP};sha256sum=${SHA256SUM_GEMMLOWP} \
     https://github.com/google/googletest/archive/release-1.8.0.tar.gz;md5sum=${MD5SUM_GTEST};sha256sum=${SHA256SUM_GTEST} \


### PR DESCRIPTION
For the convenience, this patch adds 'protocol' parameter with 'https' to SRC_URI in the bitbakse recipe for tensorflow-lite v.1.12.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped