### PR TITLE
[Recipe/NNStreamer] Rearrange packaging order of unittest

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
@@ -42,6 +42,12 @@ do_install_append() {
 }
 INSANE_SKIP_${PN} += "dev-so"
 
+PACKAGE_BEFORE_PN += "${PN}-unittest"
+FILES_${PN}-unittest += "\
+                    ${libdir}/nnstreamer/customfilters/* \
+                    ${libdir}/nnstreamer/unittest/* \
+                    "
+
 FILES_${PN} += "\
             ${libdir}/*.so \
             ${libdir}/gstreamer-1.0/*.so \
@@ -50,13 +56,6 @@ FILES_${PN} += "\
             ${libdir}/nnstreamer/decoders/* \
             ${sysconfdir}/nnstreamer.ini \
             "
-
-PACKAGES =+ "${PN}-unittest"
-
-FILES_${PN}-unittest += "\
-                    ${libdir}/nnstreamer/customfilters/* \
-                    ${libdir}/nnstreamer/unittest/* \
-                    "
 
 RDEPENDS_${PN}-unittest = "nnstreamer gstreamer1.0-plugins-good gtest python3-numpy python3-math ssat"
 


### PR DESCRIPTION
Since the unittest package includes binaries that require ${PN}, it is required to package prior to ${PN}. This patch fixes this issue.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

#### Before this PR ####
```bash
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libnnstreamer_customfilter_scaler.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libnnscustom_framecounter.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libnnstreamer_customfilter_passthrough.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libdummyLSTM.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libdummyRNN.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libnnstreamer_customfilter_average.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libnnstreamer_customfilter_scaler_allocator.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libnnstreamer_customfilter_passthrough_variable.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
WARNING: nnstreamer-0.1.2+gitAUTOINC+af05bf3266-r0 do_package: nnstreamer-0.1.2+git0+af05bf3266 was registered as shlib provider for libnnscustom_drop_buffer.so, changing it to nnstreamer-unittest-0.1.2+git0+af05bf3266 because it was built later
```