### PR TITLE
[Recipe/NNStreamer] Separate sub-plugin for tflite from the main package

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
@@ -46,17 +46,17 @@ FILES_${PN} += "\
             ${libdir}/*.so \
             ${libdir}/gstreamer-1.0/*.so \
             ${libdir}/nnstreamer/* \
-            ${libdir}/nnstreamer/filters/* \
             ${libdir}/nnstreamer/decoders/* \
             ${sysconfdir}/nnstreamer.ini \
             "
 
-PACKAGES =+ "${PN}-unittest"
+PACKAGES =+ "${PN}-unittest ${PN}-tensorflow-lite"
 
 FILES_${PN}-unittest += "\
                     ${libdir}/nnstreamer/customfilters/* \
                     ${libdir}/nnstreamer/unittest/* \
                     "
+FILES_${PN}-tensorflow-lite += "${libdir}/nnstreamer/filters/libnnstreamer_filter_tensorflow-lite.so"
 
 RDEPENDS_${PN}-unittest = "nnstreamer gstreamer1.0-plugins-good gtest python3-numpy python3-math ssat"
 


### PR DESCRIPTION
This patch extracts sub-plugin for tensorflow-lite from the main package and creates another package for it.

Signed-off-by: Wook Song <wook16.song@samsung.com>

Epic: https://github.com/nnsuite/nnstreamer/issues/1005
Resolves: https://github.com/nnsuite/nnstreamer/issues/1171

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [ ]Skipped