### PR TITLE
[Recipe/TFLite] bugfix: Create main package containing nothing

### DIFF
--- a/recipes-tensorflow/tensorflow-lite/tensorflow-lite_1.12.bb
+++ b/recipes-tensorflow/tensorflow-lite/tensorflow-lite_1.12.bb
@@ -121,3 +121,4 @@ do_install() {
     install -m 0644 ${S}/tensorflow/contrib/lite/tools/make/downloads/flatbuffers/include/flatbuffers/*.h ${D}${includedir}/flatbuffers/
 }
 
+ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Since all the other sub-packages have a dependency on the main package, ${PN} which currently does not exist, bitbake fails when trying to install those sub-packages into rootfs using such  CORE_IMAGE_EXTRA_INSTALL like variables. In order to fix this issue, this patch creates the main
package containing nothing.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped