### PR TITLE
[Recipe/NNStreamer] Add a bitbake recipe for NNStreamer-ROS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ This layer provides OFFICIAL support for [NNStreamer](https://github.com/nnsuite
 - layers: meta-oe
 - branch: master
 - revision: HEAD
+
+- URI: https://github.com/wooksong/meta-ros.git
+- branch: support-nnstremer-ros
+- revision: 8fbb949c9b7dd9fe5ab0c95e6945906b02d0bf6a

--- a/recipes-nnstreamer/nnstreamer-ros/nnstreamer-ros_0.0.1.bb
+++ b/recipes-nnstreamer/nnstreamer-ros/nnstreamer-ros_0.0.1.bb
@@ -1,0 +1,68 @@
+SUMMARY = "NNStreamer extension plugins for ROS support"
+DESCRIPTION = "A set of NNStreamer extension plugins for ROS support"
+SECTION = "AI"
+LICENSE = "LGPLv2+"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=0244e07aff1ef055b85e686207429f23"
+
+DEPENDS = "glib-2.0 gstreamer1.0 nnstreamer catkin cpp-common roscpp rosbag rospack"
+
+SRC_URI = "git://github.com/nnsuite/nnstreamer-ros.git;protocol=https"
+
+PV = "0.0.1+git${SRCPV}"
+SRCREV = "${AUTOREV}"
+S = "${WORKDIR}/git"
+BBCLASSEXTEND = "native nativesdk"
+
+ROS_VERSION = "${ROSDISTRO}"
+ROS_BASE_PREFIX = "${WORKDIR}/recipe-sysroot/opt/ros"
+ROS_ROOT = "${ROS_BASE_PREFIX}"
+ROS_INSTALL_PREFIX = "/opt/ros"
+ROS_INSTALL_BASE = "${ROS_INSTALL_PREFIX}/${ROS_VERSION}"
+
+export CMAKE_PREFIX_PATH = "/opt/ros/${ROSDISTRO}"
+export PYTHONPATH="${WORKDIR}/recipe-sysroot/opt/ros/${ROSDISTRO}/lib/python2.7/site-packages"
+
+EXTRA_OECMAKE += "\
+            -DROS_VERSION=${ROS_VERSION} \
+            -DROS_BASE_PREFIX=${ROS_BASE_PREFIX} \
+            -DROS_ROOT=${ROS_BASE_PREFIX} \
+            -DROS_INSTALL_PREFIX=${ROS_INSTALL_PREFIX} \
+            -DNNS_INSTALL_LIBDIR=${libdir} \
+             "
+
+inherit cmake
+OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
+
+do_install_append() {
+    find ${D} -name *.pyc -delete
+    rm -f ${D}${ROS_INSTALL_BASE}/.rosinstall
+    rm -f ${D}${ROS_INSTALL_BASE}/local_setup.bash
+    rm -f ${D}${ROS_INSTALL_BASE}/setup.bash
+    rm -f ${D}${ROS_INSTALL_BASE}/setup.zsh
+    rm -f ${D}${ROS_INSTALL_BASE}/local_setup.sh
+    rm -f ${D}${ROS_INSTALL_BASE}/local_setup.zsh
+    rm -f ${D}${ROS_INSTALL_BASE}/setup.sh
+    rm -f ${D}${ROS_INSTALL_BASE}/.catkin
+    rm -f ${D}${ROS_INSTALL_BASE}/env.sh
+    rm -f ${D}${ROS_INSTALL_BASE}/_setup_util.py
+    # nodejs
+    rm -rf ${D}${ROS_INSTALL_BASE}/share/gennodejs
+    find ${D} -name *.js -delete
+    # lisp
+    rm -rf ${D}${ROS_INSTALL_BASE}/share/roseus
+    rm -rf ${D}${ROS_INSTALL_BASE}/share/common-lisp
+}
+
+FILES_${PN} += "\
+                ${ROS_INSTALL_BASE}/share/nns_ros_bridge/* \
+                ${ROS_INSTALL_BASE}/lib/python2.7/dist-packages/* \
+                ${ROS_INSTALL_BASE}/lib/*.so \
+                ${libdir}/gstreamer-1.0/*.so \
+                "
+
+FILES_${PN}-dev += "\
+                ${ROS_INSTALL_BASE}/share/nns_ros_bridge/cmake/* \
+                ${ROS_INSTALL_BASE}/include/nns_ros_bridge/* \
+                ${ROS_INSTALL_BASE}/include/nns_ros_bridge/cmake/* \
+                ${ROS_INSTALL_BASE}/lib/pkgconfig/*.pc \
+                "


### PR DESCRIPTION
**In order to remove the 'DO NOT MERGE' tag, run-test is required upon the Internal Yocto Image with its  reference target device.**

This patch adds a bitbake recipe for NNStreamer-ROS, which is NNStreamer extension plugins for ROS support.

Resolves: A sub-item of https://github.com/nnsuite/nnstreamer/issues/1005
See also: https://github.com/nnsuite/nnstreamer/issues/1133
Related: https://github.com/nnsuite/nnstreamer/issues/1354

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>