### PR TITLE
[Recipe/NNStreamer] Remove build option control for OpenCV @open sesame 6/13 19:25

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
@@ -36,7 +36,6 @@ PACKAGECONFIG ??= "\
                 ${@bb.utils.contains('DISTRO_FEATURES','tensorflow','tensorflow','',d)} \
                 "
 
-PACKAGECONFIG[opencv] = "-Denable-opencv-test=true,-Denable-opencv-test=false,opencv"
 PACKAGECONFIG[tensorflow] = "-Denable-tensorflow=true,-Denable-tensorflow=false,tensorflow"
 
 do_install_append() {


### PR DESCRIPTION
Since the build option for opencv is not supported anymore, this patch removes it from the bitbake recipe.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped