### PR TITLE
[Recipe/NNStreamer] Remove unused license from LIC_FILES_CHKSUM @open sesame 6/04 09:15

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
@@ -4,7 +4,6 @@ SECTION = "AI"
 LICENSE = "LGPLv2+"
 LIC_FILES_CHKSUM = "\
                 file://LICENSE;md5=a6f89e2100d9b6cdffcea4f398e37343 \
-                file://tizen-api/LICENSE.Apache-2.0;md5=d3ae35440dea13087a83d59100346a44 \
                 file://debian/copyright;md5=0462ef8fa89a1f53f2e65e74940519ef \
                 "
 


### PR DESCRIPTION
This patch removes the license file, LICENSE.Apache-2.0, which is unused anymore, from LIC_FILES_CHKSUM.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped