### PR TITLE
[Recipe/NNStreamer] Add a local patch for skipping unsupported unit test

### DIFF
--- a/recipes-nnstreamer/nnstreamer/files/0001-Test-Common-Remove-a-unit-test-for-custom-configurat.patch
+++ b/recipes-nnstreamer/nnstreamer/files/0001-Test-Common-Remove-a-unit-test-for-custom-configurat.patch
@@ -1,0 +1,160 @@
+From 7332ab1b029ade5e554e1724fdfec772a80906d5 Mon Sep 17 00:00:00 2001
+From: Wook Song <wook16.song@samsung.com>
+Date: Wed, 5 Jun 2019 13:31:32 +0900
+Subject: [PATCH 1/1] [Test/Common] Remove a unit test for custom configuration
+
+This patch removes a unit test for custom configuration file provided by
+the environment variable since once nnstreamer is installed the
+configuration file cannot be overrided using the environment variable.
+
+Signed-off-by: Wook Song <wook16.song@samsung.com>
+---
+ tests/common/unittest_common.cpp | 132 ---------------------------------------
+ 1 file changed, 132 deletions(-)
+
+diff --git a/tests/common/unittest_common.cpp b/tests/common/unittest_common.cpp
+index 9c40cef..6914840 100644
+--- a/tests/common/unittest_common.cpp
++++ b/tests/common/unittest_common.cpp
+@@ -480,138 +480,6 @@ static gboolean check_custom_conf (const gchar *group, const gchar *key, const g
+ }
+ 
+ /**
+- * @brief Test custom configurations
+- */
+-TEST (conf_custom, env_str_01)
+-{
+-  gchar *fullpath = g_build_path ("/", g_get_tmp_dir(), "nns-tizen-XXXXXX", NULL);
+-  gchar *dir = g_mkdtemp (fullpath);
+-  gchar *filename = g_build_path ("/", dir, "nnstreamer.ini", NULL);
+-  gchar *dirf = g_build_path ("/", dir, "filters", NULL);
+-  gchar *dircf = g_build_path ("/", dir, "custom", NULL);
+-  gchar *dird = g_build_path ("/", dir, "decoders", NULL);
+-
+-  EXPECT_EQ (g_mkdir (dirf, 0755), 0);
+-  EXPECT_EQ (g_mkdir (dircf, 0755), 0);
+-  EXPECT_EQ (g_mkdir (dird, 0755), 0);
+-
+-
+-  FILE *fp = g_fopen (filename, "w");
+-  const gchar *fn;
+-  const gchar *base_confenv;
+-  gchar *confenv;
+-
+-  base_confenv = g_getenv ("NNSTREAMER_CONF");
+-  confenv = (base_confenv != NULL) ? g_strdup (base_confenv) : NULL;
+-
+-  ASSERT_TRUE (fp != NULL);
+-
+-  g_fprintf (fp, "[common]\n");
+-  g_fprintf (fp, "enable_envvar=True\n");
+-  g_fprintf (fp, "[filter]\n");
+-  g_fprintf (fp, "filters=%s\n", dirf);
+-  g_fprintf (fp, "customfilters=%s\n", dircf);
+-  g_fprintf (fp, "[decoder]\n");
+-  g_fprintf (fp, "decoders=%s\n", dird);
+-  g_fprintf (fp, "[customX]\n");
+-  g_fprintf (fp, "abc=OFF\n");
+-  g_fprintf (fp, "def=on\n");
+-  g_fprintf (fp, "ghi=TRUE\n");
+-  g_fprintf (fp, "n01=fAlSe\n");
+-  g_fprintf (fp, "n02=yeah\n");
+-  g_fprintf (fp, "n03=NAH\n");
+-  g_fprintf (fp, "n04=1\n");
+-  g_fprintf (fp, "n05=0\n");
+-  g_fprintf (fp, "mzx=whatsoever\n");
+-  g_fprintf (fp, "[customY]\n");
+-  g_fprintf (fp, "mzx=dunno\n");
+-  g_fprintf (fp, "[customZ]\n");
+-  g_fprintf (fp, "mzx=wth\n");
+-  g_fprintf (fp, "n05=1\n");
+-
+-  fclose (fp);
+-
+-  gchar *f1 = create_null_file (dirf, "libnnstreamer_filter_fantastic.so");
+-  gchar *f2 = create_null_file (dirf, "libnnstreamer_filter_neuralnetwork.so");
+-  gchar *f3 = create_null_file (dird, "libnnstreamer_decoder_omg.so");
+-  gchar *f4 = create_null_file (dird, "libnnstreamer_decoder_wthisgoingon.so");
+-  gchar *f5 = create_null_file (dircf, "custom_mechanism.so");
+-  gchar *f6 = create_null_file (dircf, "fastfaster.so");
+-
+-  EXPECT_TRUE (FALSE != g_setenv ("NNSTREAMER_CONF", filename, TRUE));
+-  EXPECT_TRUE (nnsconf_loadconf (TRUE) == TRUE);
+-
+-  fn = nnsconf_get_fullpath ("fantastic", NNSCONF_PATH_FILTERS);
+-  EXPECT_STREQ (fn, f1);
+-  fn = nnsconf_get_fullpath ("neuralnetwork", NNSCONF_PATH_FILTERS);
+-  EXPECT_STREQ (fn, f2);
+-  fn = nnsconf_get_fullpath ("notfound", NNSCONF_PATH_FILTERS);
+-  EXPECT_STREQ (fn, NULL);
+-  fn = nnsconf_get_fullpath ("omg", NNSCONF_PATH_DECODERS);
+-  EXPECT_STREQ (fn, f3);
+-  fn = nnsconf_get_fullpath ("wthisgoingon", NNSCONF_PATH_DECODERS);
+-  EXPECT_STREQ (fn, f4);
+-  fn = nnsconf_get_fullpath ("notfound", NNSCONF_PATH_DECODERS);
+-  EXPECT_STREQ (fn, NULL);
+-  fn = nnsconf_get_fullpath ("custom_mechanism", NNSCONF_PATH_CUSTOM_FILTERS);
+-  EXPECT_STREQ (fn, f5);
+-  fn = nnsconf_get_fullpath ("fastfaster", NNSCONF_PATH_CUSTOM_FILTERS);
+-  EXPECT_STREQ (fn, f6);
+-  fn = nnsconf_get_fullpath ("notfound", NNSCONF_PATH_CUSTOM_FILTERS);
+-  EXPECT_STREQ (fn, NULL);
+-
+-  EXPECT_TRUE (check_custom_conf ("customX", "abc", "OFF"));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customX", "abc", TRUE));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customX", "abc", FALSE));
+-  EXPECT_TRUE (check_custom_conf ("customX", "def", "on"));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "def", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "def", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customX", "ghi", "TRUE"));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "ghi", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "ghi", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customX", "n02", "yeah"));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "n02", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "n02", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customX", "n03", "NAH"));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customX", "n03", FALSE));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customX", "n03", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customX", "n04", "1"));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "n04", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "n04", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customX", "n05", "0"));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customX", "n05", FALSE));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customX", "n05", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customX", "mzx", "whatsoever"));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customX", "mzx", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customX", "mzx", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customY", "mzx", "dunno"));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customY", "mzx", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customY", "mzx", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customZ", "mzx", "wth"));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customZ", "mzx", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customZ", "mzx", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customZ", "n05", "1"));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customZ", "n05", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customZ", "n05", TRUE));
+-  EXPECT_TRUE (check_custom_conf ("customW", "n05", NULL));
+-  EXPECT_FALSE (nnsconf_get_custom_value_bool ("customW", "n05", FALSE));
+-  EXPECT_TRUE (nnsconf_get_custom_value_bool ("customW", "n05", TRUE));
+-
+-  if (confenv) {
+-    g_setenv ("NNSTREAMER_CONF", confenv, TRUE);
+-    g_free (confenv);
+-  } else {
+-    g_unsetenv ("NNSTREAMER_CONF");
+-  }
+-  g_free (f1);
+-  g_free (f2);
+-  g_free (f3);
+-  g_free (f4);
+-  g_free (f5);
+-  g_free (f6);
+-}
+-
+-/**
+  * @brief Main function for unit test.
+  */
+ int
+-- 
+2.7.4
+

--- a/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_0.1.2.bb
@@ -9,7 +9,10 @@ LIC_FILES_CHKSUM = "\
 
 DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gtest tensorflow-lite"
 
-SRC_URI = "git://github.com/nnsuite/nnstreamer.git;protocol=https"
+SRC_URI = "\
+        git://github.com/nnsuite/nnstreamer.git;protocol=https \
+        file://0001-Test-Common-Remove-a-unit-test-for-custom-configurat.patch \
+        "
 
 PV = "0.1.2+git${SRCPV}"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
This patch add a local patch for gstreamer to skip a unit test about custom configuration file provided by the environment variable.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>