### PR TITLE
[Recipe/NNStreamer] Exclude libnnstreamer.so from dev package

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_0.2.0.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_0.2.0.bb
@@ -63,7 +63,7 @@ RDEPENDS_${PN}-unittest = "nnstreamer gstreamer1.0-plugins-good gtest python3-nu
 
 RDEPENDS_${PN} = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base"
 
-FILES_${PN}-dev += "\
+FILES_${PN}-dev = "\
                 ${includedir}/nnstreamer/* \
                 ${libdir}/*.a \
                 ${libdir}/pkgconfig/nnstreamer.pc \


### PR DESCRIPTION
Related to https://github.com/nnsuite/nnstreamer/pull/1456

Although libnnstreamer.so is a shared object that required at runtime, this file is included in the dev package rather than the main package. This patch fixes this issue.

Signed-off-by: Wook Song <wook16.song@samsung.com>