### PR TITLE
[Conf] Update layer configuration to support 'zeus' @open sesame 10/28 11:45

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "neuralnetwork"
 
 BBFILE_PATTERN_neuralnetwork = "^${LAYERDIR}/"
 BBFILE_PRIORITY_neuralnetwork = "7"
-LAYERVERSION_neuralnetwork = "4"
-LAYERSERIES_COMPAT_neuralnetwork = "thud warrior"
+LAYERVERSION_neuralnetwork = "5"
+LAYERSERIES_COMPAT_neuralnetwork = "warrior zeus"


### PR DESCRIPTION
Resolves the CI failure in #41 
Related to https://github.com/nnsuite/nnstreamer/pull/1816

This patch updates the layer configuration to support 'zeus and to remove 'thus' from the list of compatible Yocto Project releases.

Note that 'warrior' will be also removed from the list of compatible Yocto Project releases soon.

Signed-off-by: Wook Song <wook16.song@samsung.com>