### PR TITLE
[Recipe/NNStreamer] Bump up the version of NNStreamer to 1.0.0

### DIFF
--- a/recipes-nnstreamer/nnstreamer/nnstreamer_1.0.0.bb
+++ b/recipes-nnstreamer/nnstreamer/nnstreamer_1.0.0.bb
@@ -18,8 +18,8 @@ SRC_URI = "\
         file://0001-Test-Common-Remove-a-unit-test-for-custom-configurat.patch \
         "
 
-PV = "0.2.0+git${SRCPV}"
-SRCREV = "${AUTOREV}"
+PV = "1.0.0+git${SRCPV}"
+SRCREV = "720ce6ec7f68325dfd1e6c2ded6024e805f3eff2"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This PR may fixes the failure in our system (#41). IMO, since only `zeus` provides meson > 0.50, to keep the version of NNStreamer as https://github.com/nnsuite/nnstreamer/releases/tag/v1.0.0 is the only way to stay in `warrior`.

Therefore, instead of using ${AUTOREV}, this patch modifies SRCREV to the latest stable version of NNStreamer, v1.0.0.

Signed-off-by: Wook Song <wook16.song@samsung.com>