### PR TITLE
[Recipe/SSAT] Update upstream source URI

### DIFF
--- a/recipes-devtools/ssat/ssat_1.0.0.bb
+++ b/recipes-devtools/ssat/ssat_1.0.0.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://debian/copyright;md5=9ad9849cc2d52d5b8200d053d510e7d2"
 
-SRC_URI = "git://github.com/nnsuite/SSAT.git;protocol=https"
+SRC_URI = "git://github.com/myungjoo/SSAT.git;protocol=https"
 
 PV = "1.0.0+git${SRCPV}"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
Since nnsuite/ssat in GitHub is no longer available, this patch updates the source URI in the recipe file to point that of the upstream.

Signed-off-by: Wook Song <wook16.song@samsung.com>